### PR TITLE
PE-4417: feat(save files on app dir)

### DIFF
--- a/.fvm/fvm_config.json
+++ b/.fvm/fvm_config.json
@@ -1,4 +1,4 @@
 {
-  "flutterSdkVersion": "3.10.0",
+  "flutterSdkVersion": "3.10.2",
   "flavors": {}
 }

--- a/lib/ardrive_io.dart
+++ b/lib/ardrive_io.dart
@@ -8,6 +8,7 @@ export 'src/io_entity.dart';
 export 'src/io_exception.dart';
 export 'src/io_file.dart';
 export 'src/io_folder.dart';
+export 'src/mobile/mobile_io.dart';
 export 'src/utils/mime_type_utils.dart';
 export 'src/utils/path_utils.dart';
 export 'src/utils/permissions.dart';

--- a/lib/src/utils/path_utils.dart
+++ b/lib/src/utils/path_utils.dart
@@ -48,6 +48,12 @@ Future<String> getDefaultMobileDownloadDir() async {
   }
 }
 
+Future<String> getDefaultAppDir() {
+  return path_provider
+      .getApplicationDocumentsDirectory()
+      .then((value) => value.path + '/');
+}
+
 /// Returns the file extension from the file `name`, when having, in other case the extension
 /// will be provided by the `contentType`.
 ///

--- a/lib/src/web/web_io.dart
+++ b/lib/src/web/web_io.dart
@@ -49,7 +49,8 @@ class WebIO implements ArDriveIO {
 
   @override
   Future<void> saveFile(IOFile file) async {
-    final savePath = await file_selector.getSavePath();
+    final savePath = await file_selector.getSaveLocation();
+    
     if (savePath == null) {
       throw EntityPathException();
     }
@@ -59,7 +60,7 @@ class WebIO implements ArDriveIO {
       lastModified: file.lastModifiedDate,
       mimeType: file.contentType,
       name: file.name,
-    ).saveTo(savePath);
+    ).saveTo(savePath.path);
   }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   mime: ^1.0.2
   equatable: ^2.0.3
   file_selector: ^0.9.0
-  flutter_downloader: ^1.8.3+2
+  flutter_downloader: 1.10.3
   image_picker: ^0.8.5+3
   security_scoped_resource: ^0.0.1
   file_saver:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.15.1 <3.0.0"
-  flutter: 3.10.0
+  flutter: 3.10.2
 
 dependencies:
   flutter:


### PR DESCRIPTION
### Release notes:
- add a method to save files on local app dir - ps: only mobile!

### Important: 
On this PR we are replacing the deprecated method `getSavePath` with `getSaveLocation` used on the `saveFile` method on the `WebIO` implementation.