### PR TITLE
v1.4.1

### DIFF
--- a/lib/src/io_file.dart
+++ b/lib/src/io_file.dart
@@ -106,7 +106,8 @@ class IOFileAdapter {
 
   Future<IOFile> fromXFile(XFile file) async {
     final lastModified = await file.lastModified();
-    final contentType = lookupMimeTypeWithDefaultType(file.path);
+    final contentType =
+        file.mimeType ?? lookupMimeTypeWithDefaultType(file.path);
 
     return _FromXFile(
       file,

--- a/lib/src/utils/mime_type_utils.dart
+++ b/lib/src/utils/mime_type_utils.dart
@@ -14,8 +14,6 @@ String? lookupMimeType(String path, {List<int>? headerBytes}) {
     return applicationGZip;
   }
 
-  print(path);
-
   return mime.lookupMimeType(path, headerBytes: headerBytes);
 }
 

--- a/lib/src/utils/mime_type_utils.dart
+++ b/lib/src/utils/mime_type_utils.dart
@@ -14,6 +14,8 @@ String? lookupMimeType(String path, {List<int>? headerBytes}) {
     return applicationGZip;
   }
 
+  print(path);
+
   return mime.lookupMimeType(path, headerBytes: headerBytes);
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ardrive_io
 description: A new Flutter package project.
-version: 1.4.0
+version: 1.4.1
 homepage:
 publish_to: none
 


### PR DESCRIPTION
### Release Notes
- When using drag and drop the file path resolves to similar to: blob:http://localhost:54203/5628ef94-ffda-4c1e-981c-5decd535b579. Now, if the contentType is provided, the `formXFile` will use it.