### PR TITLE
fix(IOFile)

### DIFF
--- a/lib/src/io_file.dart
+++ b/lib/src/io_file.dart
@@ -106,8 +106,13 @@ class IOFileAdapter {
 
   Future<IOFile> fromXFile(XFile file) async {
     final lastModified = await file.lastModified();
-    final contentType =
-        file.mimeType ?? lookupMimeTypeWithDefaultType(file.path);
+    String contentType;
+
+    if (file.mimeType != null && file.mimeType!.isNotEmpty) {
+      contentType = file.mimeType!;
+    } else {
+      contentType = lookupMimeTypeWithDefaultType(file.path);
+    }
 
     return _FromXFile(
       file,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ardrive_io
 description: A new Flutter package project.
-version: 1.4.6
+version: 1.4.7
 homepage:
 publish_to: none
 


### PR DESCRIPTION
### Release Notes
Fix: Corrected MIME type assignment for files in fromXFile method of IOFileAdapter
- Resolved an issue where files with empty or null MIME types were not correctly assigned a default MIME type.